### PR TITLE
Fix Monado <-> ILLIXR Timing

### DIFF
--- a/src/xrt/compositor/client/comp_gl_client.c
+++ b/src/xrt/compositor/client/comp_gl_client.c
@@ -147,15 +147,14 @@ client_gl_compositor_end_frame(struct xrt_compositor *xc,
 	}
 
 	// Pipe down call into fd compositor.
-	/*
-	c->xcfd->base.end_frame(&c->xcfd->base, blend_mode, internal,
-	                        image_index, layers, num_swapchains);*/
-	struct client_gl_swapchain *lsc = client_gl_swapchain(xscs[0]);
-	struct client_gl_swapchain *rsc = client_gl_swapchain(xscs[1]);
-	unsigned int left = lsc->base.images[image_index[0]];
-	unsigned int right = rsc->base.images[image_index[1]];
-	
-	illixr_write_frame(left, right);
+
+	// c->xcfd->base.end_frame(&c->xcfd->base, blend_mode, internal,
+	//                         image_index, layers, num_swapchains);
+
+	// We have to pass xscs instead of internal because ILLIXR needs the texture
+	// IDs and internal doesn't have them
+	c->xcfd->base.end_frame(&c->xcfd->base, blend_mode, xscs,
+	                        image_index, layers, num_swapchains);
 }
 
 static int64_t

--- a/src/xrt/compositor/client/comp_gl_client.c
+++ b/src/xrt/compositor/client/comp_gl_client.c
@@ -134,25 +134,25 @@ client_gl_compositor_end_frame(struct xrt_compositor *xc,
                                uint32_t num_swapchains)
 {
 	struct client_gl_compositor *c = client_gl_compositor(xc);
-	struct xrt_swapchain *internal[8];
+	// struct xrt_swapchain *internal[8];
 
 	if (num_swapchains > 8) {
 		fprintf(stderr, "ERROR! %s\n", __func__);
 		return;
 	}
 
-	for (uint32_t i = 0; i < num_swapchains; i++) {
-		struct client_gl_swapchain *sc = client_gl_swapchain(xscs[i]);
-		internal[i] = &sc->xscfd->base;
-	}
+	// for (uint32_t i = 0; i < num_swapchains; i++) {
+	// 	struct client_gl_swapchain *sc = client_gl_swapchain(xscs[i]);
+	// 	internal[i] = &sc->xscfd->base;
+	// }
 
 	// Pipe down call into fd compositor.
 
 	// c->xcfd->base.end_frame(&c->xcfd->base, blend_mode, internal,
 	//                         image_index, layers, num_swapchains);
 
-	// We have to pass xscs instead of internal because ILLIXR needs the texture
-	// IDs and internal doesn't have them
+	// We have to pass 'xscs' instead of 'internal' because ILLIXR needs
+	// the texture IDs and 'internal' doesn't have them
 	c->xcfd->base.end_frame(&c->xcfd->base, blend_mode, xscs,
 	                        image_index, layers, num_swapchains);
 }

--- a/src/xrt/compositor/main/comp_compositor.c
+++ b/src/xrt/compositor/main/comp_compositor.c
@@ -55,6 +55,7 @@
 
 #include "main/comp_compositor.h"
 #include "main/comp_client_interface.h"
+#include "../drivers/illixr/illixr_component.h"
 
 #include <unistd.h>
 #include <math.h>
@@ -238,14 +239,16 @@ compositor_end_frame(struct xrt_compositor *xc,
 	struct comp_compositor *c = comp_compositor(xc);
 	COMP_SPEW(c, "END_FRAME");
 
-	struct comp_swapchain_image *right;
-	struct comp_swapchain_image *left;
-
 	// Stereo!
 	if (num_swapchains == 2) {
-		left = &comp_swapchain(xscs[0])->images[image_index[0]];
-		right = &comp_swapchain(xscs[1])->images[image_index[1]];
-		comp_renderer_frame(c->r, left, layers[0], right, layers[1]);
+		// struct comp_swapchain_image *right;
+		// struct comp_swapchain_image *left;
+		// left = &comp_swapchain(xscs[0])->images[image_index[0]];
+		// right = &comp_swapchain(xscs[1])->images[image_index[1]];
+		// comp_renderer_frame(c->r, left, layers[0], right, layers[1]);
+		unsigned int left = xrt_swapchain_gl(xscs[0])->images[image_index[0]];
+		unsigned int right = xrt_swapchain_gl(xscs[1])->images[image_index[1]];
+		illixr_write_frame(left, right);
 	} else {
 		COMP_ERROR(c, "non-stereo rendering not supported");
 	}

--- a/src/xrt/compositor/main/comp_compositor.c
+++ b/src/xrt/compositor/main/comp_compositor.c
@@ -783,9 +783,9 @@ comp_compositor_create(struct xrt_device *xdev,
 
 	c->settings.flip_y = flip_y;
 	c->last_frame_time_ns = time_state_get_now(c->timekeeping);
-	c->frame_overhead_ns = 2000000;
+	c->frame_overhead_ns = 4000000;
 	//! @todo set this to an estimate that's better than 6ms
-	c->expected_app_duration_ns = 6000000;
+	c->expected_app_duration_ns = 10000000;
 
 
 	// Need to select window backend before creating Vulkan, then

--- a/src/xrt/compositor/main/comp_compositor.c
+++ b/src/xrt/compositor/main/comp_compositor.c
@@ -130,7 +130,7 @@ static bool
 compositor_wait_vsync_or_time(struct comp_compositor *c, int64_t wake_up_time)
 {
 
-	int64_t now_ns = time_state_get_now(c->timekeeping);
+	int64_t now_ns = illixr_get_now_ns();
 	/*!
 	 * @todo this is not accurate, but it serves the purpose of not letting
 	 * us sleep longer than the next vsync usually
@@ -154,7 +154,7 @@ compositor_wait_vsync_or_time(struct comp_compositor *c, int64_t wake_up_time)
 	}
 	// Busy-wait for fine-grained delays.
 	while (now_ns < wake_up_time) {
-		now_ns = time_state_get_now(c->timekeeping);
+		now_ns = illixr_get_now_ns();
 	}
 
 	return ret;
@@ -170,12 +170,13 @@ compositor_wait_frame(struct xrt_compositor *xc,
 	// A little bit easier to read.
 	int64_t interval_ns = (int64_t)c->settings.nominal_frame_interval_ns;
 
-	int64_t now_ns = time_state_get_now(c->timekeeping);
+	int64_t now_ns = illixr_get_now_ns();
 	if (c->last_next_display_time == 0) {
 		// First frame, we'll just assume we will display immediately
 
 		*predicted_display_period = interval_ns;
-		c->last_next_display_time = now_ns + interval_ns;
+		//c->last_next_display_time = now_ns + interval_ns;
+		c->last_next_display_time = illixr_get_vsync_ns();
 		*predicted_display_time = c->last_next_display_time;
 		return;
 	}

--- a/src/xrt/compositor/main/comp_compositor.c
+++ b/src/xrt/compositor/main/comp_compositor.c
@@ -785,7 +785,7 @@ comp_compositor_create(struct xrt_device *xdev,
 	c->last_frame_time_ns = time_state_get_now(c->timekeeping);
 	c->frame_overhead_ns = 4000000;
 	//! @todo set this to an estimate that's better than 6ms
-	c->expected_app_duration_ns = 10000000;
+	c->expected_app_duration_ns = 2000000;
 
 
 	// Need to select window backend before creating Vulkan, then

--- a/src/xrt/drivers/illixr/illixr_component.cpp
+++ b/src/xrt/drivers/illixr/illixr_component.cpp
@@ -21,11 +21,13 @@ public:
 		, sb{pb->lookup_impl<switchboard>()}
 		, sb_pose{pb->lookup_impl<pose_prediction>()}
 		, sb_eyebuffer{sb->publish<rendered_frame_alt>("eyebuffer")}
+		, sb_vsync_estimate{sb->subscribe_latest<time_type>("vsync_estimate")}
 	{ }
 
 	const std::shared_ptr<switchboard> sb;
 	const std::shared_ptr<pose_prediction> sb_pose;
 	const std::unique_ptr<writer<rendered_frame_alt>> sb_eyebuffer;
+	const std::unique_ptr<reader_latest<time_type>> sb_vsync_estimate;
 	pose_type prev_pose; /* stores a copy of pose_type each time illixr_read_pose() is called */
 	std::chrono::time_point<std::chrono::system_clock> sample_time; /* when prev_pose was stored */
 };
@@ -75,6 +77,25 @@ extern "C" void illixr_write_frame(unsigned int left,
 	frame->texture_handles[1] = right;
 	frame->render_pose = illixr_plugin_obj->prev_pose;
 	frame->sample_time = illixr_plugin_obj->sample_time;
+	frame->render_time = std::chrono::high_resolution_clock::now();
 
 	illixr_plugin_obj->sb_eyebuffer->put(frame);
+}
+
+extern "C" int64_t illixr_get_vsync_ns() {
+	assert(illixr_plugin_obj && "illixr_plugin_obj must be initialized first.");
+
+	const time_type *vsync_estimate = illixr_plugin_obj->sb_vsync_estimate->get_latest_ro();
+	
+	if(vsync_estimate == nullptr)
+	{
+		return std::chrono::duration_cast<std::chrono::nanoseconds>((std::chrono::system_clock::now()).time_since_epoch()).count() + NANO_SEC/60;
+	}
+
+	return std::chrono::duration_cast<std::chrono::nanoseconds>((*vsync_estimate).time_since_epoch()).count();
+}
+
+extern "C" int64_t illixr_get_now_ns() {
+	assert(illixr_plugin_obj && "illixr_plugin_obj must be initialized first.");
+	return std::chrono::duration_cast<std::chrono::nanoseconds>((std::chrono::system_clock::now()).time_since_epoch()).count();
 }

--- a/src/xrt/drivers/illixr/illixr_component.cpp
+++ b/src/xrt/drivers/illixr/illixr_component.cpp
@@ -19,12 +19,12 @@ public:
 	illixr_plugin(std::string name_, phonebook* pb_)
 		: plugin{name_, pb_}
 		, sb{pb->lookup_impl<switchboard>()}
-		, sb_pose{pb->lookup_impl<const pose_prediction>()}
+		, sb_pose{pb->lookup_impl<pose_prediction>()}
 		, sb_eyebuffer{sb->publish<rendered_frame_alt>("eyebuffer")}
 	{ }
 
 	const std::shared_ptr<switchboard> sb;
-	const std::shared_ptr<const pose_prediction> sb_pose;
+	const std::shared_ptr<pose_prediction> sb_pose;
 	const std::unique_ptr<writer<rendered_frame_alt>> sb_eyebuffer;
 	pose_type prev_pose; /* stores a copy of pose_type each time illixr_read_pose() is called */
 	std::chrono::time_point<std::chrono::system_clock> sample_time; /* when prev_pose was stored */

--- a/src/xrt/drivers/illixr/illixr_component.cpp
+++ b/src/xrt/drivers/illixr/illixr_component.cpp
@@ -44,7 +44,7 @@ extern "C" plugin* illixr_monado_create_plugin(phonebook* pb) {
 extern "C" struct xrt_pose illixr_read_pose() {
 	assert(illixr_plugin_obj && "illixr_plugin_obj must be initialized first.");
 
-	const pose_type pose = illixr_plugin_obj->sb_pose->get_fast_pose();
+	const pose_type pose = illixr_plugin_obj->sb_pose->get_fast_pose().pose;
 	if (!illixr_plugin_obj->sb_pose->fast_pose_reliable()) {
 		std::cerr << "Pose not reliable yet; returning best guess" << std::endl;
 	}
@@ -75,7 +75,9 @@ extern "C" void illixr_write_frame(unsigned int left,
 
 	frame->texture_handles[0] = left;
 	frame->texture_handles[1] = right;
-	frame->render_pose = illixr_plugin_obj->prev_pose;
+	frame->render_pose = fast_pose_type{
+		.pose = illixr_plugin_obj->prev_pose
+	};
 	frame->sample_time = illixr_plugin_obj->sample_time;
 	frame->render_time = std::chrono::high_resolution_clock::now();
 
@@ -96,6 +98,6 @@ extern "C" int64_t illixr_get_vsync_ns() {
 }
 
 extern "C" int64_t illixr_get_now_ns() {
-	assert(illixr_plugin_obj && "illixr_plugin_obj must be initialized first.");
+	//assert(illixr_plugin_obj && "illixr_plugin_obj must be initialized first.");
 	return std::chrono::duration_cast<std::chrono::nanoseconds>((std::chrono::system_clock::now()).time_since_epoch()).count();
 }

--- a/src/xrt/drivers/illixr/illixr_component.h
+++ b/src/xrt/drivers/illixr/illixr_component.h
@@ -9,6 +9,8 @@ struct xrt_pose illixr_read_pose();
 
 void illixr_write_frame(unsigned int left,
                         unsigned int right);
+int64_t illixr_get_vsync_ns();
+int64_t illixr_get_now_ns();
 void get_illixr_context();
 
 #ifdef __cplusplus

--- a/src/xrt/state_trackers/oxr/oxr_session_gl.c
+++ b/src/xrt/state_trackers/oxr/oxr_session_gl.c
@@ -43,11 +43,11 @@ oxr_session_populate_gl_xlib(struct oxr_logger *log,
 	sess->compositor = &xcgl->base;
 	sess->create_swapchain = oxr_swapchain_gl_create;
 
-    // HACK FOR ILLIXR
-    sess->sys->xdevs[0]->set_output(sess->sys->xdevs[0], 0, (void*)next->glxContext, NULL);
-    glXMakeCurrent(next->xDisplay,
-                   next->glxDrawable,
-                   next->glxContext);
+	// HACK FOR ILLIXR
+	sess->sys->xdevs[0]->set_output(sess->sys->xdevs[0], 0, (void*)next->glxContext, NULL);
+	glXMakeCurrent(next->xDisplay,
+	    next->glxDrawable,
+	    next->glxContext);
 
 	return XR_SUCCESS;
 }


### PR DESCRIPTION
xrWaitFrame and xrEndFrame need to rely on ILLIXR to correctly perform their functions. This is not done at the moment, and so the applications are not synchronized with the runtime at all.