### PR TITLE
Disable Monado Window

### DIFF
--- a/src/xrt/compositor/main/comp_window_xcb.cpp
+++ b/src/xrt/compositor/main/comp_window_xcb.cpp
@@ -208,7 +208,8 @@ comp_window_xcb_init(struct comp_window *w)
 	if (w->c->settings.fullscreen)
 		comp_window_xcb_set_full_screen(w_xcb);
 
-	xcb_map_window(w_xcb->connection, w_xcb->window);
+	// We do not need a separate window in ILLIXR
+	// xcb_map_window(w_xcb->connection, w_xcb->window);
 
 	return true;
 }


### PR DESCRIPTION
Disable Monado's rendering window because it interferes with `apitrace`. It is not used anyway.